### PR TITLE
Fixed typo

### DIFF
--- a/content/en/cv.html
+++ b/content/en/cv.html
@@ -150,7 +150,7 @@ C++, C. Network programming. Compilation and static analysis.
 
 {% endcall %}
 
-## Personnel projects
+## Personal projects
 
 {% call cvblock('Since 2009', 'GNU/Linux Magazine France', 'Author') %}
 


### PR DESCRIPTION
the french "personnel" translates to "personal" in English. See http://www.wordreference.com/fren/personnel
