### PR TITLE
Change broadcast address of 192.168.117.0/26

### DIFF
--- a/content/en/blog/2017-ipv4-route-lookup-linux.html
+++ b/content/en/blog/2017-ipv4-route-lookup-linux.html
@@ -343,7 +343,7 @@ configured. Let's look at the three last lines. When the IP address
 automatically added the appropriate routes:
 
  - a route for `192.168.117.55` for local unicast delivery to the IP address,
- - a route for `192.168.117.255` for broadcast delivery to the broadcast address,
+ - a route for `192.168.117.63` for broadcast delivery to the broadcast address,
  - a route for `192.168.117.0` for broadcast delivery to the network address.
 
 When `127.0.0.1` was configured on the loopback interface, the same

--- a/content/fr/blog/2017-ipv4-table-routage-linux.html
+++ b/content/fr/blog/2017-ipv4-table-routage-linux.html
@@ -366,7 +366,7 @@ l'interface `eno1`, trois nouvelles routes ont été ajoutées
 automatiquement :
 
  - une route pour `192.168.117.55` pour la livraison locale en unicast,
- - une route pour `192.168.117.255` pour une livraison de type « *broadcast* »,
+ - une route pour `192.168.117.63` pour une livraison de type « *broadcast* »,
  - une route pour `192.168.117.0` pour une livraison de type « *broadcast* » vers l'adresse de réseau.
 
 Quand `127.0.0.1` est configurée sur l'interface de *loopback*, des


### PR DESCRIPTION
Bonjour,

Tout d'abord, merci beaucoup pour ces excellents posts, c'est rare de trouver des blogs d'une telle qualité !

En dégustant le post sur les lookups, je me suis aperçu d'une mini faute de frappe sur l'adresse de broadcast du réseau utilisé dans les exemples :  192.168.117.0/26 et donc voici une PR qui propose une correction.

Merci encore !

Signed-off-by: jpmondet <jp@mondet.org>